### PR TITLE
Clarify group order 18338

### DIFF
--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -496,6 +496,11 @@ class GroupKFold(_BaseKFold):
      [7 8]] [[1 2]
      [3 4]] [3 4] [1 2]
 
+    Notes
+    -----
+    The groups will be in an arbitrary order
+
+
     See Also
     --------
     LeaveOneGroupOut : For splitting the data according to explicit
@@ -1137,6 +1142,10 @@ class LeaveOneGroupOut(BaseCrossValidator):
     [[1 2]
      [3 4]] [[5 6]
      [7 8]] [1 2] [1 2]
+
+    Notes
+    -----
+    groups will be sorted depending to the index left out.
 
     """
 

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1020,22 +1020,26 @@ def test_leave_one_p_group_out():
 
 def test_leave_group_out_is_ordered():
     # Check that LeaveOneGroupOut orders the splits
-    groups = np.array([1, 0, 3, 2, 4, 5])
-    X = np.ones(6)
+    groups = np.array([1, 1, 3, 2, 4, 4, 4, 6])
+    X = np.ones(8)
 
     splits = iter(LeaveOneGroupOut().split(X, groups=groups))
 
     train, test = next(splits)
-    assert_array_equal(train, [0, 2, 3, 4, 5])
-    assert_array_equal(test, [1])
+    assert_array_equal(train, [2, 3, 4, 5, 6, 7])
+    assert_array_equal(test, [0, 1])
 
     train, test = next(splits)
-    assert_array_equal(train, [1, 2, 3, 4, 5])
-    assert_array_equal(test, [0])
-
-    train, test = next(splits)
-    assert_array_equal(train, [0, 1, 2, 4, 5])
+    assert_array_equal(train, [0, 1, 2, 4, 5, 6, 7])
     assert_array_equal(test, [3])
+
+    train, test = next(splits)
+    assert_array_equal(train, [0, 1, 3, 4, 5, 6, 7])
+    assert_array_equal(test, [2])
+
+    train, test = next(splits)
+    assert_array_equal(train, [0, 1, 2, 3, 7])
+    assert_array_equal(test, [4, 5, 6])
 
 def test_leave_group_out_changing_groups():
     # Check that LeaveOneGroupOut and LeavePGroupsOut work normally if

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1018,6 +1018,24 @@ def test_leave_one_p_group_out():
     with pytest.raises(ValueError, match=msg):
         lpgo_1.get_n_splits(None, None, None)
 
+def test_leave_group_out_is_ordered():
+    # Check that LeaveOneGroupOut orders the splits
+    groups = np.array([1, 0, 3, 2, 4, 5])
+    X = np.ones(6)
+
+    splits = iter(LeaveOneGroupOut().split(X, groups=groups))
+
+    train, test = next(splits)
+    assert_array_equal(train, [0, 2, 3, 4, 5])
+    assert_array_equal(test, [1])
+
+    train, test = next(splits)
+    assert_array_equal(train, [1, 2, 3, 4, 5])
+    assert_array_equal(test, [0])
+
+    train, test = next(splits)
+    assert_array_equal(train, [0, 1, 2, 4, 5])
+    assert_array_equal(test, [3])
 
 def test_leave_group_out_changing_groups():
     # Check that LeaveOneGroupOut and LeavePGroupsOut work normally if


### PR DESCRIPTION

This is a pull request to solve the clarity between functions in [issue 18338](https://github.com/scikit-learn/scikit-learn/issues/18338)

Changes made:
- added a new test case that checks LeaveOneGroupOut has ordering in the splits
- added documentation to clarify the differences between LeaveOneGroupOut and GroupKFold