### PR TITLE
Skip tests if non_determinism = True

### DIFF
--- a/sklearn/tests/test_nondeterminism.py
+++ b/sklearn/tests/test_nondeterminism.py
@@ -1,0 +1,34 @@
+import numpy as np
+from sklearn.utils.estimator_checks import parametrize_with_checks
+from sklearn.base import BaseEstimator, ClassifierMixin, check_X_y
+from sklearn.utils.validation import check_array, check_is_fitted, check_random_state
+
+class TemplateEstimator(BaseEstimator, ClassifierMixin):
+    def __init__(self, threshold=0.5, random_state=None):
+        self.threshold = threshold
+        self.random_state = random_state
+    
+    def fit(self, X, y):
+        self.random_state_ = check_random_state(self.random_state)
+        X, y = check_X_y(X, y)
+        self.classes_ = np.unique(y)
+        self.fitted_ = True
+        return self
+    
+    def predict(self, X):
+        check_is_fitted(self)
+        X = check_array(X)
+
+        y_hat = self.random_state_.choice(self.classes_, size=X.shape[0])
+        return y_hat
+    
+    def _more_tags(self):
+        return {
+            "non_deterministic": True,
+            "no_validation": True,
+            "poor_score": True,
+        }
+    
+@parametrize_with_checks([TemplateEstimator()])
+def test_sklearn_compatible_estimator(estimator, check):
+    check(estimator)

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1282,6 +1282,9 @@ def _apply_on_subsets(func, X):
 def check_methods_subset_invariance(name, estimator_orig):
     # check that method gives invariant results if applied
     # on mini batches or the whole set
+    if _safe_tags(estimator_orig, key="non_deterministic"):
+        msg = name + " is non deterministic"
+        raise SkipTest(msg)
     rnd = np.random.RandomState(0)
     X = 3 * rnd.uniform(size=(20, 3))
     X = _pairwise_estimator_convert_X(X, estimator_orig)
@@ -1318,6 +1321,9 @@ def check_methods_subset_invariance(name, estimator_orig):
 
 @ignore_warnings(category=FutureWarning)
 def check_methods_sample_order_invariance(name, estimator_orig):
+    if _safe_tags(estimator_orig, key="non_deterministic"):
+        msg = name + " is non deterministic"
+        raise SkipTest(msg)
     # check that method gives invariant results if applied
     # on a subset with different sample order
     rnd = np.random.RandomState(0)


### PR DESCRIPTION
This PR fixes [https://github.com/scikit-learn/scikit-learn/issues/22313](url) by adding a check for the non_determinism tag in those test cases and skipping if it is set to True. Furthermore, we added a test case for testing non determinism so future changes should not break non deterministic code